### PR TITLE
Bq feat load time

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -149,6 +149,7 @@ class _AuthGateState extends State<AuthGate> with WidgetsBindingObserver {
     final analytics = context.read<AnalyticsService>();
     if (state == AppLifecycleState.paused ||
         state == AppLifecycleState.detached) {
+      analytics.discardPendingLoad();
       analytics.endSession();
     } else if (state == AppLifecycleState.resumed) {
       analytics.startSession();

--- a/lib/services/analytics_service.dart
+++ b/lib/services/analytics_service.dart
@@ -16,11 +16,53 @@ class ScreenName {
 
 class AnalyticsService {
   final ApiClient _apiClient;
-  final LocalDbService _localDb = LocalDbService(); 
+  final LocalDbService _localDb = LocalDbService();
   String? _sessionId;
   String? currentScreen;
 
+  Stopwatch? _loadStopwatch;
+  String? _pendingLoadScreen;
+
   AnalyticsService(this._apiClient);
+
+  void markFeatureLoadStart(String screenName) {
+    _pendingLoadScreen = screenName;
+    _loadStopwatch = Stopwatch()..start();
+  }
+
+  // Drops the in-flight timer without posting. Call this when the app is
+  // backgrounded — a paused user isn't "still loading."
+  void discardPendingLoad() {
+    _loadStopwatch = null;
+    _pendingLoadScreen = null;
+  }
+
+  Future<void> markFeatureLoadEnd(String screenName) async {
+    final sw = _loadStopwatch;
+    // Screen-name gate prevents a stale stopwatch from attributing to the
+    // wrong screen if the user switched tabs mid-load.
+    if (sw == null || _pendingLoadScreen != screenName || _sessionId == null) {
+      return;
+    }
+    sw.stop();
+    final elapsedMs = sw.elapsedMilliseconds;
+    _loadStopwatch = null;
+    _pendingLoadScreen = null;
+
+    try {
+      await _apiClient.post(
+        '/analytics/events',
+        data: {
+          'sessionId': _sessionId,
+          'eventType': 'FEATURE_LOAD_TIME',
+          'screenName': screenName,
+          'payload': {'screen': screenName, 'durationMs': elapsedMs},
+        },
+      );
+    } catch (e) {
+      debugPrint('Failed to report feature load time: $e');
+    }
+  }
 
   Future<void> startSession() async {
     _sessionId = const Uuid().v4();

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -15,7 +15,7 @@ class ApiClient {
   //   flutter run --dart-define=API_BASE_URL=https://xxxx.ngrok-free.app/api
   static const String _baseUrl = String.fromEnvironment(
     'API_BASE_URL',
-    defaultValue: 'http://10.0.2.2:3000/api',
+    defaultValue: 'http://localhost:3000/api',
   );
 
   final Dio _dio;

--- a/lib/views/home_screen.dart
+++ b/lib/views/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:provider/provider.dart';
 import '../models/app_notification.dart';
 import '../models/property_model.dart';
 import '../utils/app_theme.dart';
+import '../services/analytics_service.dart';
 import '../viewmodels/home_viewmodel.dart';
 import '../viewmodels/main_page_viewmodel.dart';
 
@@ -31,8 +32,10 @@ class _HomeScreenState extends State<HomeScreen> with WidgetsBindingObserver {
     _homeVM = context.read<HomeViewModel>();
     WidgetsBinding.instance.addObserver(this);
     _listScrollController.addListener(_onListScroll);
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _homeVM.fetchProperties();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final analytics = context.read<AnalyticsService>();
+      await _homeVM.fetchProperties();
+      await analytics.markFeatureLoadEnd(ScreenName.home);
       _homeVM.fetchNotifications();
       _homeVM.startNotificationsPolling();
     });

--- a/lib/views/main_page.dart
+++ b/lib/views/main_page.dart
@@ -13,9 +13,14 @@ import '../viewmodels/main_page_viewmodel.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
 
 class _ScreenTracker extends StatefulWidget {
-  const _ScreenTracker({required this.screenName, required this.child});
+  const _ScreenTracker({
+    required this.screenName,
+    required this.child,
+    this.autoEndLoadTimeOnFirstFrame = false,
+  });
   final String screenName;
   final Widget child;
+  final bool autoEndLoadTimeOnFirstFrame;
 
   @override
   State<_ScreenTracker> createState() => _ScreenTrackerState();
@@ -25,7 +30,13 @@ class _ScreenTrackerState extends State<_ScreenTracker> {
   @override
   void initState() {
     super.initState();
-    context.read<AnalyticsService>().currentScreen = widget.screenName;
+    final analytics = context.read<AnalyticsService>();
+    analytics.currentScreen = widget.screenName;
+    if (widget.autoEndLoadTimeOnFirstFrame) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        analytics.markFeatureLoadEnd(widget.screenName);
+      });
+    }
   }
 
   @override
@@ -65,7 +76,19 @@ class _MainPageState extends State<MainPage> {
     super.dispose();
   }
 
+  static const List<String> _screenNamesByIndex = [
+    ScreenName.home,
+    ScreenName.mapSearch,
+    ScreenName.chatScreen,
+    ScreenName.feed,
+    ScreenName.roomies,
+    ScreenName.profileEdit,
+  ];
+
   void _changePage(int value) {
+    context.read<AnalyticsService>().markFeatureLoadStart(
+      _screenNamesByIndex[value],
+    );
     setState(() {
       currentPage = value;
     });
@@ -191,15 +214,22 @@ class _MainPageState extends State<MainPage> {
     const _ScreenTracker(screenName: ScreenName.mapSearch, child: MapScreen()),
     const _ScreenTracker(
       screenName: ScreenName.chatScreen,
+      autoEndLoadTimeOnFirstFrame: true,
       child: ChatsScreen(),
     ),
-    const _ScreenTracker(screenName: ScreenName.feed, child: FeedScreen()),
+    const _ScreenTracker(
+      screenName: ScreenName.feed,
+      autoEndLoadTimeOnFirstFrame: true,
+      child: FeedScreen(),
+    ),
     const _ScreenTracker(
       screenName: ScreenName.roomies,
+      autoEndLoadTimeOnFirstFrame: true,
       child: RoomiesScreen(),
     ),
     const _ScreenTracker(
       screenName: ScreenName.profileEdit,
+      autoEndLoadTimeOnFirstFrame: true,
       child: ProfileScreen(),
     ),
   ];

--- a/lib/views/map_screen.dart
+++ b/lib/views/map_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_lucide/flutter_lucide.dart';
+import '../services/analytics_service.dart';
 import '../viewmodels/map_view_model.dart';
 import '../models/property_model.dart';
 import '../utils/app_theme.dart';
@@ -27,8 +28,10 @@ class _MapScreenState extends State<MapScreen> {
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<MapViewModel>().initializeMap();
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final analytics = context.read<AnalyticsService>();
+      await context.read<MapViewModel>().initializeMap();
+      await analytics.markFeatureLoadEnd(ScreenName.mapSearch);
     });
   }
 


### PR DESCRIPTION
This pull request introduces feature load time analytics to the app, enabling tracking of how long it takes for each major feature screen to load. The changes include new methods for marking the start and end of feature loads, automatic instrumentation in the main navigation flow, and clean-up when the app is backgrounded. Additionally, the default API base URL is updated for local development.

**Feature Load Time Analytics:**

* Added `markFeatureLoadStart`, `markFeatureLoadEnd`, and `discardPendingLoad` methods to `AnalyticsService` for tracking and reporting feature load times, with safeguards against misattribution and cleanup when the app is paused. (`lib/services/analytics_service.dart`)
* Integrated feature load time tracking into the main navigation: when switching pages, `markFeatureLoadStart` is called, and on first frame of key screens, `markFeatureLoadEnd` is triggered to record load completion. (`lib/views/main_page.dart`, `lib/views/home_screen.dart`, `lib/views/map_screen.dart`) [[1]](diffhunk://#diff-7c6787958699aa8c7abd80bf6ba6a4995f30f3a1f09a996be643f7aa66cf51d2R79-R91) [[2]](diffhunk://#diff-7c6787958699aa8c7abd80bf6ba6a4995f30f3a1f09a996be643f7aa66cf51d2R217-R232) [[3]](diffhunk://#diff-7c6787958699aa8c7abd80bf6ba6a4995f30f3a1f09a996be643f7aa66cf51d2L28-R39) [[4]](diffhunk://#diff-7c6787958699aa8c7abd80bf6ba6a4995f30f3a1f09a996be643f7aa66cf51d2L16-R23) [[5]](diffhunk://#diff-9d89554023cc5a565e6903c1f80fafc04db9c257f4ebe73b4caea2f3c761f366L35-R39) [[6]](diffhunk://#diff-8f7ea13b612cc29b948b86e19fc903c2fe54f0715abcab47cd26aa64bc4ea68cL30-R34)
* Ensured that pending load timers are discarded when the app is paused or detached, preventing inaccurate analytics. (`lib/main.dart`)

**Codebase and Dependency Updates:**

* Updated the default API base URL for local development from `10.0.2.2` to `localhost`, simplifying setup. (`lib/services/api_client.dart`)
* Added necessary imports for `AnalyticsService` in affected files. (`lib/views/home_screen.dart`, `lib/views/map_screen.dart`) [[1]](diffhunk://#diff-9d89554023cc5a565e6903c1f80fafc04db9c257f4ebe73b4caea2f3c761f366R10) [[2]](diffhunk://#diff-8f7ea13b612cc29b948b86e19fc903c2fe54f0715abcab47cd26aa64bc4ea68cR7)